### PR TITLE
DEV-434-split-commands

### DIFF
--- a/cmd/operatorcli/main.go
+++ b/cmd/operatorcli/main.go
@@ -84,17 +84,26 @@ var commandGenerateBLSKey = &cli.Command{
 	Flags:       []cli.Flag{},
 }
 
-var commandEOChainSetAlias = &cli.Command{
-	Name:        "eochain-set-alias",
-	Description: "Create or Import a ECDSA private key only for oracle chain. The command can also update the eochain with the alias",
-	Action:      runEOChainSetAlias,
+var commandGenerateAlias = &cli.Command{
+	Name:        "generate-alias",
+	Description: "Create or Import an ECDSA private key only for oracle chain",
+	Action:      runGenerateAlias,
 	Flags:       []cli.Flag{
 		flag.EcdsaPrivateKeyFlag,
 		flag.PassphraseFlag,
 		flag.KeyStorePathFlag,
-		flag.EOChainEthRPCFlag,
-		flag.EncryptOnlyFlag,
 		flag.OverrideFlag,
+	},
+}
+
+var commandDeclareAlias = &cli.Command{
+	Name:        "declare-alias",
+	Description: "Declare the alias in the eochain",
+	Action:      runDeclareAlias,
+	Flags:       []cli.Flag{
+		flag.PassphraseFlag,
+		flag.KeyStorePathFlag,
+		flag.EOChainEthRPCFlag,
 		flag.EOConfigAddressFlag,
 	},
 }
@@ -111,7 +120,8 @@ func main() {
 		commandDeregister,
 		commandPrintStatus,
 		commandGenerateBLSKey,
-		commandEOChainSetAlias,
+		commandGenerateAlias,
+		commandDeclareAlias,
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -144,6 +154,10 @@ func runGenerateBLSKey(c *cli.Context) error {
 	return operatorcli.RunGenerateBLSKey(c)
 }
 
-func runEOChainSetAlias(c *cli.Context) error {
-	return operatorcli.RunEOChainSetAlias(c)
+func runGenerateAlias(c *cli.Context) error {
+	return operatorcli.RunGenerateAlias(c)
+}
+
+func runDeclareAlias(c *cli.Context) error {
+	return operatorcli.RunDeclareAlias(c)
 }

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -17,9 +17,9 @@ var (
 		Value:       ".keystore",
 	}
 	EthRPCFlag = &cli.StringFlag{
-		Name:    "eth-rpc",
+		Name:    "eth-rpc-endpoint",
 		Usage:   "ethereum rpc url",
-		EnvVars: []string{"EO_ETH_RPC"},
+		EnvVars: []string{"ETH_RPC_ENDPOINT"},
 	}
 	RegistryCoordinatorFlag = &cli.StringFlag{
 		Name:    "registry-coordinator",
@@ -80,8 +80,8 @@ var (
 		Value:       0,
 	}
 	EOChainEthRPCFlag = &cli.StringFlag{
-		Name:    "eochaineth-rpc",
-		Usage:   "eochain ethereum rpc url",
+		Name:    "eochain-rpc-endpoint",
+		Usage:   "eochain rpc url",
 		EnvVars: []string{"EO_CHAIN_RPC_ENDPOINT"},
 	}
 	EncryptOnlyFlag = &cli.BoolFlag{
@@ -92,9 +92,9 @@ var (
 		Value:       false,
 	}
 	OverrideFlag = &cli.BoolFlag{
-		Name:        "override",
+		Name:        "alias-override",
 		Usage:       "Indication if a new alias key should be created",
-		EnvVars:     []string{"EO_OVERRIDE"},
+		EnvVars:     []string{"EO_ALIAS_OVERRIDE"},
 		DefaultText: "False",
 		Value:       false,
 	}


### PR DESCRIPTION
split the set-alias command into two commands:
* generate-alias -- importing or generating an ECDSA key and ecrypt it
* declare-alia -- declaring the alias in eoracle chain