### PR TITLE
Add support for specifying per-key password

### DIFF
--- a/cmd/operatorcli/main.go
+++ b/cmd/operatorcli/main.go
@@ -30,7 +30,7 @@ var commandDecrypt = &cli.Command{
 		flag.PassphraseFlag,
 		flag.BlsPassphraseFlag,
 		flag.EcdsaPassphraseFlag,
-		flag.EcdsaAliasedPassphraseFlag,
+		flag.AliasedEcdsaPassphraseFlag,
 		flag.KeyStorePathFlag,
 	},
 }
@@ -96,8 +96,8 @@ var commandGenerateAlias = &cli.Command{
 	Description: "Create or Import an ECDSA private key only for oracle chain",
 	Action:      runGenerateAlias,
 	Flags:       []cli.Flag{
-		flag.EcdsaPrivateKeyFlag,
-		flag.EcdsaAliasedPassphraseFlag,
+		flag.AliasedEcdsaPrivateKeyFlag,
+		flag.AliasedEcdsaPassphraseFlag,
 		flag.KeyStorePathFlag,
 		flag.OverrideFlag,
 	},
@@ -110,7 +110,7 @@ var commandDeclareAlias = &cli.Command{
 	Flags:       []cli.Flag{
 		flag.PassphraseFlag,
 		flag.EcdsaPassphraseFlag,
-		flag.EcdsaAliasedPassphraseFlag,
+		flag.AliasedEcdsaPassphraseFlag,
 		flag.KeyStorePathFlag,
 		flag.EOChainEthRPCFlag,
 		flag.EOConfigAddressFlag,

--- a/cmd/operatorcli/main.go
+++ b/cmd/operatorcli/main.go
@@ -16,7 +16,9 @@ var commandEncrypt = &cli.Command{
 	Flags: []cli.Flag{
 		flag.EcdsaPrivateKeyFlag,
 		flag.BlsPrivateKeyFlag,
-		flag.PassphraseFlag,
+		flag.BlsPassphraseFlag,
+		flag.EcdsaPassphraseFlag,
+		flag.EcdsaAliasedPassphraseFlag,
 		flag.KeyStorePathFlag,
 	},
 }
@@ -25,7 +27,9 @@ var commandDecrypt = &cli.Command{
 	Description: "Decrypt the ecdsa and bls private keys",
 	Action:      runDecrypt,
 	Flags: []cli.Flag{
-		flag.PassphraseFlag,
+		flag.BlsPassphraseFlag,
+		flag.EcdsaPassphraseFlag,
+		flag.EcdsaAliasedPassphraseFlag,
 		flag.KeyStorePathFlag,
 	},
 }
@@ -37,7 +41,8 @@ var commandRegister = &cli.Command{
 	Flags: []cli.Flag{
 		flag.EthRPCFlag,
 		flag.RegistryCoordinatorFlag,
-		flag.PassphraseFlag,
+		flag.BlsPassphraseFlag,
+		flag.EcdsaPassphraseFlag,
 		flag.KeyStorePathFlag,
 		flag.SaltFlag,
 		flag.ExpiryFlag,
@@ -56,7 +61,7 @@ var commandDeregister = &cli.Command{
 	Flags: []cli.Flag{
 		flag.EthRPCFlag,
 		flag.RegistryCoordinatorFlag,
-		flag.PassphraseFlag,
+		flag.EcdsaPassphraseFlag,
 		flag.KeyStorePathFlag,
 		flag.EcdsaPrivateKeyFlag,
 		flag.QuorumNumberFlag,
@@ -70,7 +75,7 @@ var commandPrintStatus = &cli.Command{
 	Flags: []cli.Flag{
 		flag.EthRPCFlag,
 		flag.RegistryCoordinatorFlag,
-		flag.PassphraseFlag,
+		flag.EcdsaPassphraseFlag,
 		flag.KeyStorePathFlag,
 		flag.EcdsaPrivateKeyFlag,
 		flag.QuorumNumberFlag,
@@ -101,7 +106,8 @@ var commandDeclareAlias = &cli.Command{
 	Description: "Declare the alias in the eochain",
 	Action:      runDeclareAlias,
 	Flags:       []cli.Flag{
-		flag.PassphraseFlag,
+		flag.EcdsaPassphraseFlag,
+		flag.EcdsaAliasedPassphraseFlag,
 		flag.KeyStorePathFlag,
 		flag.EOChainEthRPCFlag,
 		flag.EOConfigAddressFlag,

--- a/cmd/operatorcli/main.go
+++ b/cmd/operatorcli/main.go
@@ -19,7 +19,6 @@ var commandEncrypt = &cli.Command{
 		flag.PassphraseFlag,
 		flag.BlsPassphraseFlag,
 		flag.EcdsaPassphraseFlag,
-		flag.EcdsaAliasedPassphraseFlag,
 		flag.KeyStorePathFlag,
 	},
 }
@@ -98,7 +97,7 @@ var commandGenerateAlias = &cli.Command{
 	Action:      runGenerateAlias,
 	Flags:       []cli.Flag{
 		flag.EcdsaPrivateKeyFlag,
-		flag.PassphraseFlag,
+		flag.EcdsaAliasedPassphraseFlag,
 		flag.KeyStorePathFlag,
 		flag.OverrideFlag,
 	},

--- a/cmd/operatorcli/main.go
+++ b/cmd/operatorcli/main.go
@@ -16,6 +16,7 @@ var commandEncrypt = &cli.Command{
 	Flags: []cli.Flag{
 		flag.EcdsaPrivateKeyFlag,
 		flag.BlsPrivateKeyFlag,
+		flag.PassphraseFlag,
 		flag.BlsPassphraseFlag,
 		flag.EcdsaPassphraseFlag,
 		flag.EcdsaAliasedPassphraseFlag,
@@ -27,6 +28,7 @@ var commandDecrypt = &cli.Command{
 	Description: "Decrypt the ecdsa and bls private keys",
 	Action:      runDecrypt,
 	Flags: []cli.Flag{
+		flag.PassphraseFlag,
 		flag.BlsPassphraseFlag,
 		flag.EcdsaPassphraseFlag,
 		flag.EcdsaAliasedPassphraseFlag,
@@ -41,6 +43,7 @@ var commandRegister = &cli.Command{
 	Flags: []cli.Flag{
 		flag.EthRPCFlag,
 		flag.RegistryCoordinatorFlag,
+		flag.PassphraseFlag,
 		flag.BlsPassphraseFlag,
 		flag.EcdsaPassphraseFlag,
 		flag.KeyStorePathFlag,
@@ -106,6 +109,7 @@ var commandDeclareAlias = &cli.Command{
 	Description: "Declare the alias in the eochain",
 	Action:      runDeclareAlias,
 	Flags:       []cli.Flag{
+		flag.PassphraseFlag,
 		flag.EcdsaPassphraseFlag,
 		flag.EcdsaAliasedPassphraseFlag,
 		flag.KeyStorePathFlag,

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -60,6 +60,21 @@ var (
 		Usage:   "passphrase to open the encrypted private key",
 		EnvVars: []string{"EO_PASSPHRASE"},
 	}
+	BlsPassphraseFlag = &cli.StringFlag{
+		Name:    "bls-passphrase",
+		Usage:   "passphrase to open the encrypted BLS private key",
+		EnvVars: []string{"EO_BLS_PASSPHRASE"},
+	}
+	EcdsaPassphraseFlag = &cli.StringFlag{
+		Name:    "ecdsa-passphrase",
+		Usage:   "passphrase to open the encrypted ECDSA private key",
+		EnvVars: []string{"EO_ECDSA_PASSPHRASE"},
+	}
+	EcdsaAliasedPassphraseFlag = &cli.StringFlag{
+		Name:    "ecdsa-aliased-passphrase",
+		Usage:   "passphrase to open the encrypted aliased ECDSA private key",
+		EnvVars: []string{"EO_ALIASED_ECDSA_PASSPHRASE"},
+	}
 	ValidatorRoleFlag = &cli.StringFlag{
 		Name:        "validator-role",
 		Usage:       "role of the operator",

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -36,6 +36,11 @@ var (
 		Usage:   "ecdsa private key",
 		EnvVars: []string{"EO_ECDSA_PRIVATE_KEY"},
 	}
+	AliasedEcdsaPrivateKeyFlag = &cli.StringFlag{
+		Name:    "aliased-ecdsa-private-key",
+		Usage:   "aliased ecdsa private key",
+		EnvVars: []string{"EO_ALIASED_ECDSA_PRIVATE_KEY"},
+	}
 	BlsPrivateKeyFlag = &cli.StringFlag{
 		Name:    "bls-private-key",
 		Usage:   "bls private key",
@@ -70,8 +75,8 @@ var (
 		Usage:   "passphrase to open the encrypted ECDSA private key",
 		EnvVars: []string{"EO_ECDSA_PASSPHRASE"},
 	}
-	EcdsaAliasedPassphraseFlag = &cli.StringFlag{
-		Name:    "ecdsa-aliased-passphrase",
+	AliasedEcdsaPassphraseFlag = &cli.StringFlag{
+		Name:    "aliased-ecdsa-passphrase",
 		Usage:   "passphrase to open the encrypted aliased ECDSA private key",
 		EnvVars: []string{"EO_ALIASED_ECDSA_PASSPHRASE"},
 	}

--- a/internal/operatorcli/operator_cli.go
+++ b/internal/operatorcli/operator_cli.go
@@ -47,14 +47,17 @@ type avsClient struct {
 }
 
 func RunEncrypt(c *cli.Context) error {
+	passphrase := c.String(flag.PassphraseFlag.Name)
 	blsPassphrase := c.String(flag.BlsPassphraseFlag.Name)
-	if blsPassphrase == "" {
-		return cli.Exit("BLS passphrase is required", 1)
-	}
-
 	ecdsaPassphrase := c.String(flag.EcdsaPassphraseFlag.Name)
-	if ecdsaPassphrase == "" {
-		return cli.Exit("ECDSA passphrase is required", 1)
+
+	if passphrase == "" {
+		if blsPassphrase == "" || ecdsaPassphrase == "" {
+			return cli.Exit("either passphrase or bls/ecdsa passphrase is required", 1)
+		}
+	} else {
+		blsPassphrase = passphrase
+		ecdsaPassphrase = passphrase
 	}
 
 	keyStorePath := c.String(flag.KeyStorePathFlag.Name)
@@ -88,19 +91,19 @@ func RunEncrypt(c *cli.Context) error {
 }
 
 func RunDecrypt(c *cli.Context) error {
+	passphrase := c.String(flag.PassphraseFlag.Name)
 	blsPassphrase := c.String(flag.BlsPassphraseFlag.Name)
-	if blsPassphrase == "" {
-		return cli.Exit("BLS passphrase is required", 1)
-	}
-
 	ecdsaPassphrase := c.String(flag.EcdsaPassphraseFlag.Name)
-	if ecdsaPassphrase == "" {
-		return cli.Exit("ECDSA passphrase is required", 1)
-	}
-
 	ecdsaAliasedPassphrase := c.String(flag.EcdsaAliasedPassphraseFlag.Name)
-	if ecdsaAliasedPassphrase == "" {
-		return cli.Exit("ECDSA aliased passphrase is required", 1)
+
+	if passphrase == "" {
+		if blsPassphrase == "" || ecdsaPassphrase == "" || ecdsaAliasedPassphrase == "" {
+			return cli.Exit("either passphrase or bls/ecdsa/aliased ecdsa passphrase is required", 1)
+		}
+	} else {
+		blsPassphrase = passphrase
+		ecdsaPassphrase = passphrase
+		ecdsaAliasedPassphrase = passphrase
 	}
 
 	keyStorePath := c.String(flag.KeyStorePathFlag.Name)
@@ -134,8 +137,9 @@ func RunDecrypt(c *cli.Context) error {
 }
 
 func RunRegister(c *cli.Context) error {
-	ecdsaPassphrase := c.String(flag.EcdsaPassphraseFlag.Name)
+	passphrase := c.String(flag.PassphraseFlag.Name)
 	blsPassphrase := c.String(flag.BlsPassphraseFlag.Name)
+	ecdsaPassphrase := c.String(flag.EcdsaPassphraseFlag.Name)
 	keyStorePath := c.String(flag.KeyStorePathFlag.Name)
 
 	var ecdsaPair *ecdsa.PrivateKey
@@ -147,7 +151,12 @@ func RunRegister(c *cli.Context) error {
 		return cli.Exit(fmt.Sprintf("error creating logger %v", err), 1)
 	}
 
-	if ecdsaPassphrase == "" || blsPassphrase == "" || keyStorePath == "" {
+	if passphrase != "" {
+		blsPassphrase = passphrase
+		ecdsaPassphrase = passphrase
+	}
+
+	if blsPassphrase == "" || ecdsaPassphrase == "" || keyStorePath == "" {
 		if c.String(flag.EcdsaPrivateKeyFlag.Name) == "" || c.String(flag.BlsPrivateKeyFlag.Name) == "" {
 			return cli.Exit("either ecdsa/bls passphrase and keystore-path or ecdsa-private-key and bls-private-key are required", 1)
 		}
@@ -549,14 +558,17 @@ func RunDeclareAlias(c *cli.Context) error {
 		return cli.Exit(fmt.Sprintf("Error creating logger %v", err), 1)
 	}
 
+	passphrase := c.String(flag.PassphraseFlag.Name)
 	ecdsaPassphrase := c.String(flag.EcdsaPassphraseFlag.Name)
-	if ecdsaPassphrase == "" {
-		return cli.Exit("ECDSA passphrase is required", 1)
-	}
-
 	ecdsaAliasedPassphrase := c.String(flag.EcdsaAliasedPassphraseFlag.Name)
-	if ecdsaAliasedPassphrase == "" {
-		return cli.Exit("ECDSA aliased passphrase is required", 1)
+
+	if passphrase == "" {
+		if ecdsaPassphrase == "" || ecdsaAliasedPassphrase == "" {
+			return cli.Exit("either passphrase or ecdsa/aliased ecdsa passphrase is required", 1)
+		}
+	} else {
+		ecdsaPassphrase = passphrase
+		ecdsaAliasedPassphrase = passphrase
 	}
 
 	keyStorePath := c.String(flag.KeyStorePathFlag.Name)

--- a/internal/operatorcli/operator_cli.go
+++ b/internal/operatorcli/operator_cli.go
@@ -94,16 +94,16 @@ func RunDecrypt(c *cli.Context) error {
 	passphrase := c.String(flag.PassphraseFlag.Name)
 	blsPassphrase := c.String(flag.BlsPassphraseFlag.Name)
 	ecdsaPassphrase := c.String(flag.EcdsaPassphraseFlag.Name)
-	ecdsaAliasedPassphrase := c.String(flag.EcdsaAliasedPassphraseFlag.Name)
+	aliasedEcdsaPassphrase := c.String(flag.AliasedEcdsaPassphraseFlag.Name)
 
 	if passphrase == "" {
-		if blsPassphrase == "" || ecdsaPassphrase == "" || ecdsaAliasedPassphrase == "" {
+		if blsPassphrase == "" || ecdsaPassphrase == "" || aliasedEcdsaPassphrase == "" {
 			return cli.Exit("either passphrase or bls/ecdsa/aliased ecdsa passphrase is required", 1)
 		}
 	} else {
 		blsPassphrase = passphrase
 		ecdsaPassphrase = passphrase
-		ecdsaAliasedPassphrase = passphrase
+		aliasedEcdsaPassphrase = passphrase
 	}
 
 	keyStorePath := c.String(flag.KeyStorePathFlag.Name)
@@ -123,7 +123,7 @@ func RunDecrypt(c *cli.Context) error {
 	}
 	fmt.Println("bls address G1, G2 ", blsKeyPair.GetPubKeyG1().String(), ", ", blsKeyPair.GetPubKeyG2().String(), "private key", blsKeyPair.PrivKey.String())
 
-	ecdsaEOChainPair, err := eigensdkecdsa.ReadKey(filepath.Join(keyStorePath, "ecdsaAliasedEncryptedWallet.json"), ecdsaAliasedPassphrase)
+	ecdsaEOChainPair, err := eigensdkecdsa.ReadKey(filepath.Join(keyStorePath, "ecdsaAliasedEncryptedWallet.json"), aliasedEcdsaPassphrase)
 	if err != nil {
 		if err == os.ErrNotExist {
 			fmt.Println("eochain alias was not set in the system")
@@ -489,8 +489,8 @@ func RunGenerateBLSKey(c *cli.Context) error {
 }
 
 func RunGenerateAlias(c *cli.Context) error {
-	ecdsaAliasedPassphrase := c.String(flag.EcdsaAliasedPassphraseFlag.Name)
-	if ecdsaAliasedPassphrase == "" {
+	aliasedEcdsaPassphrase := c.String(flag.AliasedEcdsaPassphraseFlag.Name)
+	if aliasedEcdsaPassphrase == "" {
 		return cli.Exit("aliased ecdsa passphrase is required", 1)
 	}
 
@@ -512,7 +512,7 @@ func RunGenerateAlias(c *cli.Context) error {
 
 	var err error
 	var aliasEcdsaPair *ecdsa.PrivateKey
-	aliasEcdsaPair, err = eigensdkecdsa.ReadKey(filepath.Join(keyStorePath, "ecdsaAliasedEncryptedWallet.json"), ecdsaAliasedPassphrase)
+	aliasEcdsaPair, err = eigensdkecdsa.ReadKey(filepath.Join(keyStorePath, "ecdsaAliasedEncryptedWallet.json"), aliasedEcdsaPassphrase)
 	if err != nil {
 		// there was an error reading the alias key (either the file doesn't exist or it is corrupted), consider as if the alias doesn't exist
 		if c.String(flag.EcdsaPrivateKeyFlag.Name) != "" {
@@ -543,7 +543,7 @@ func RunGenerateAlias(c *cli.Context) error {
 	}
 
 	// Save the private key to a file
-	if err = eigensdkecdsa.WriteKey(filepath.Join(keyStorePath, "ecdsaAliasedEncryptedWallet.json"), aliasEcdsaPair, ecdsaAliasedPassphrase); err != nil {
+	if err = eigensdkecdsa.WriteKey(filepath.Join(keyStorePath, "ecdsaAliasedEncryptedWallet.json"), aliasEcdsaPair, aliasedEcdsaPassphrase); err != nil {
 		return cli.Exit(fmt.Sprintf("Error writing the ecdsaAliasedEncryptedWallet.json file %v", err), 1)
 	}
 
@@ -560,15 +560,15 @@ func RunDeclareAlias(c *cli.Context) error {
 
 	passphrase := c.String(flag.PassphraseFlag.Name)
 	ecdsaPassphrase := c.String(flag.EcdsaPassphraseFlag.Name)
-	ecdsaAliasedPassphrase := c.String(flag.EcdsaAliasedPassphraseFlag.Name)
+	aliasedEcdsaPassphrase := c.String(flag.AliasedEcdsaPassphraseFlag.Name)
 
 	if passphrase == "" {
-		if ecdsaPassphrase == "" || ecdsaAliasedPassphrase == "" {
+		if ecdsaPassphrase == "" || aliasedEcdsaPassphrase == "" {
 			return cli.Exit("either passphrase or ecdsa/aliased ecdsa passphrase is required", 1)
 		}
 	} else {
 		ecdsaPassphrase = passphrase
-		ecdsaAliasedPassphrase = passphrase
+		aliasedEcdsaPassphrase = passphrase
 	}
 
 	keyStorePath := c.String(flag.KeyStorePathFlag.Name)
@@ -581,7 +581,7 @@ func RunDeclareAlias(c *cli.Context) error {
 		return cli.Exit(fmt.Sprintf("Failed to read ecdsaEncryptedWallet.json file %v", err), 1)
 	}
 
-	aliasEcdsaPair, err := eigensdkecdsa.ReadKey(filepath.Join(keyStorePath, "ecdsaAliasedEncryptedWallet.json"), ecdsaAliasedPassphrase)
+	aliasEcdsaPair, err := eigensdkecdsa.ReadKey(filepath.Join(keyStorePath, "ecdsaAliasedEncryptedWallet.json"), aliasedEcdsaPassphrase)
 	if err != nil {
 		return cli.Exit(fmt.Sprintf("Failed to read ecdsaAliasedEncryptedWallet.json file %v", err), 1)
 	}

--- a/internal/operatorcli/operator_cli.go
+++ b/internal/operatorcli/operator_cli.go
@@ -158,7 +158,7 @@ func RunRegister(c *cli.Context) error {
 
 	if blsPassphrase == "" || ecdsaPassphrase == "" || keyStorePath == "" {
 		if c.String(flag.EcdsaPrivateKeyFlag.Name) == "" || c.String(flag.BlsPrivateKeyFlag.Name) == "" {
-			return cli.Exit("either ecdsa/bls passphrase and keystore-path or ecdsa-private-key and bls-private-key are required", 1)
+			return cli.Exit("either general/ecdsa/bls passphrase and keystore-path or ecdsa-private-key and bls-private-key are required", 1)
 		}
 		ecdsaPair, err = crypto.HexToECDSA(c.String(flag.EcdsaPrivateKeyFlag.Name))
 		if err != nil {
@@ -489,9 +489,9 @@ func RunGenerateBLSKey(c *cli.Context) error {
 }
 
 func RunGenerateAlias(c *cli.Context) error {
-	passphrase := c.String(flag.PassphraseFlag.Name)
-	if passphrase == "" {
-		return cli.Exit("passphrase is required", 1)
+	ecdsaAliasedPassphrase := c.String(flag.EcdsaAliasedPassphraseFlag.Name)
+	if ecdsaAliasedPassphrase == "" {
+		return cli.Exit("aliased ecdsa passphrase is required", 1)
 	}
 
 	keyStorePath := c.String(flag.KeyStorePathFlag.Name)
@@ -512,7 +512,7 @@ func RunGenerateAlias(c *cli.Context) error {
 
 	var err error
 	var aliasEcdsaPair *ecdsa.PrivateKey
-	aliasEcdsaPair, err = eigensdkecdsa.ReadKey(filepath.Join(keyStorePath, "ecdsaAliasedEncryptedWallet.json"), passphrase)
+	aliasEcdsaPair, err = eigensdkecdsa.ReadKey(filepath.Join(keyStorePath, "ecdsaAliasedEncryptedWallet.json"), ecdsaAliasedPassphrase)
 	if err != nil {
 		// there was an error reading the alias key (either the file doesn't exist or it is corrupted), consider as if the alias doesn't exist
 		if c.String(flag.EcdsaPrivateKeyFlag.Name) != "" {
@@ -543,7 +543,7 @@ func RunGenerateAlias(c *cli.Context) error {
 	}
 
 	// Save the private key to a file
-	if err = eigensdkecdsa.WriteKey(filepath.Join(keyStorePath, "ecdsaAliasedEncryptedWallet.json"), aliasEcdsaPair, passphrase); err != nil {
+	if err = eigensdkecdsa.WriteKey(filepath.Join(keyStorePath, "ecdsaAliasedEncryptedWallet.json"), aliasEcdsaPair, ecdsaAliasedPassphrase); err != nil {
 		return cli.Exit(fmt.Sprintf("Error writing the ecdsaAliasedEncryptedWallet.json file %v", err), 1)
 	}
 


### PR DESCRIPTION
This pull request adds support for specifying a different passwords for each key. It is useful if you plan to use a different password for BLS, ECDSA and aliased ECDSA keys.